### PR TITLE
Automated resources generation

### DIFF
--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -36,3 +36,8 @@ tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile>().all {
         jvmTarget = "1.8"
     }
 }
+
+tasks.named<Copy>("processResources") {
+    val jsBrowserDistribution = project(":frontend").tasks.named("browserDistribution")
+    from(jsBrowserDistribution) { into("static") }
+}

--- a/backend/src/main/kotlin/Application.kt
+++ b/backend/src/main/kotlin/Application.kt
@@ -20,7 +20,7 @@ fun Application.module() {
         getResults(dsl)
         getFields(dsl)
         static {
-            staticRootFolder = File("../frontend/build/distributions")
+            staticRootFolder = File("build/resources/main/static")
             default("index.html")
             files(".")
         }


### PR DESCRIPTION
Automated resources generation: before execution  of `:backend:run` task `:frontend:browserDistribution` task is run and its result is placed in `:backend` subproject resource directory.