### PR TITLE
Cosmetic changes of gradle build scripts

### DIFF
--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
-    id("org.jetbrains.kotlin.jvm")
-    id("org.jetbrains.kotlin.plugin.serialization")
+    kotlin("jvm")
+    kotlin("plugin.serialization")
     application
 }
 
@@ -28,7 +28,7 @@ dependencies {
 }
 
 application {
-    mainClassName = "ApplicationKt"
+    mainClass.set("ApplicationKt")
 }
 
 tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompile>().all {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,11 +1,9 @@
 group = "org.example"
 version = "1.0-SNAPSHOT"
 
-plugins {
-    id("org.jetbrains.kotlin.js") version "1.4.30" apply(false)
-    id("org.jetbrains.kotlin.plugin.serialization") version "1.4.30" apply(false)
-}
-
-repositories {
-    mavenCentral()
+allprojects {
+    repositories {
+        mavenCentral()
+        jcenter()
+    }
 }

--- a/frontend/build.gradle.kts
+++ b/frontend/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-    id("org.jetbrains.kotlin.js")
+    kotlin("js")
 }
 
 group = "org.example"

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,4 +1,17 @@
 rootProject.name = "KotlinLine"
 
+pluginManagement {
+    repositories {
+        gradlePluginPortal()
+    }
+    plugins {
+        val kotlin_version : String = "1.4.30"
+
+        kotlin("jvm") version kotlin_version
+        kotlin("js") version kotlin_version
+        kotlin("plugin.serialization") version kotlin_version
+    }
+}
+
 include("frontend")
 include("backend")


### PR DESCRIPTION
Cosmetic modification of gradle build scripts:
1. `id("org.jetbrains.kotlin, ...")` is replaced with `kotlin("...")` (just readability).
2. `mainClassName = ...` is replaced with `mainClass.set(...)` due to deprecation of `mainClassName`.
3. All used repository definition in subprojects moved to universal definition in global project.
4. Putting plugins to classpath replaced with common plugin management description. 